### PR TITLE
Add support for HTMLBlock

### DIFF
--- a/cliriculum/markdown.py
+++ b/cliriculum/markdown.py
@@ -1,10 +1,11 @@
 import re
-from mistletoe import Document
 from mistletoe.block_token import Heading
 from mistletoe.span_token import RawText
 from cliriculum.deserializers import Dates, Contact
 from typing import List, Union
 import os
+from cliriculum.parsers import Document
+
 
 
 class URLEntry:
@@ -216,6 +217,7 @@ class ParseMd:
 
         >>> from cliriculum.renderers import Renderer
         >>> from cliriculum.deserializers import Dates
+        >>> from cliriculum.markdown import ParseMd
         >>> from cliriculum.loaders import load_json
         >>> parsed = ParseMd("README.md")
         >>> dates = Dates(**load_json("dates.json"))

--- a/cliriculum/parsers.py
+++ b/cliriculum/parsers.py
@@ -1,0 +1,51 @@
+from mistletoe.block_token import BlockCode, Heading, Quote, CodeFence, ThematicBreak, List, Table, Footnote, HTMLBlock, Paragraph, span_token
+from mistletoe.block_tokenizer import tokenize
+
+
+# override mistletoe.block_token.Document defaults.
+__all__ = ['BlockCode', 'Heading', 'Quote', 'CodeFence', 'ThematicBreak', 'List', 'Table', 'Footnote', "HTMLBlock", 'Paragraph']
+_token_types = [globals()[cls_name] for cls_name in __all__]
+
+
+class Document:
+    """
+    Copied from [mistletoe.block_token.Document](https://github.com/miyuchina/mistletoe/blob/276a7ec0f3ac541d93cec1fdb2fef582e48d9956/mistletoe/block_token.py#L136-L151)
+    Instance attribute children is modified. I decided to copy instead of inherit the class to fix a scope issue.
+
+    A copy of the original mistletoe license is available down below:
+
+    The MIT License
+
+    Copyright 2017 Mi Yu
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is furnished to do
+    so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """    
+    token_types = _token_types
+    
+    def __init__(self, lines):
+        if isinstance(lines, str):
+            lines = lines.splitlines(keepends=True)
+        lines = [line if line.endswith('\n') else '{}\n'.format(line) for line in lines]
+        self.footnotes = {}
+        global _root_node
+        _root_node = self
+        span_token._root_node = self
+        self.children = tokenize(lines, self.token_types)
+        span_token._root_node = None
+        _root_node = None

--- a/example/index.html
+++ b/example/index.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="style.css" type="text/css">
   <link rel="stylesheet" href="fontawesome/css/all.css" type="text/css">
   <link rel="stylesheet" href="fontawesome/css/v4-shims.css" type="text/css">
+  
   <script src="paged.polyfill.js"></script>
   <script src="style.js"></script>
 </head>
@@ -34,7 +35,9 @@
 <li>Python</li>
 <li>CSS</li>
 <li>HTML</li>
-</ul><p>And much more bullet points</p><ul>
+</ul><p>A bit of html</p><h2>
+H2
+</h2><p>And much more bullet points</p><ul>
 <li>...</li>
 <li>...</li>
 <li>...</li>

--- a/tests/fixtures/sidebar.md
+++ b/tests/fixtures/sidebar.md
@@ -9,6 +9,12 @@
 * CSS
 * HTML
 
+A bit of html
+
+<h2>
+H2
+</h2>
+
 And much more bullet points
 
 * ...


### PR DESCRIPTION
This PR adds HTMLBlock support by overriding a little `mistletoe.Document` code.